### PR TITLE
Remove quantity field from products page

### DIFF
--- a/assets/scripts/templates/cart.handlebars
+++ b/assets/scripts/templates/cart.handlebars
@@ -8,7 +8,7 @@ be displayed, through this mechanism, on the landingPage -->
  <td><p>{{product.name}}</p></td>
  <td><p>{{product.price}}</p></td>
  <td><fieldset>
-   <input value="1" class='text-field' type="number" name='id'>
+   <input min="0" max="999" value="1" class='text-field' type="number" name='id'>
  </fieldset></td>
 
 

--- a/assets/scripts/templates/products.handlebars
+++ b/assets/scripts/templates/products.handlebars
@@ -20,7 +20,6 @@ item with the specified quanity to the shopping cart -->
   <form class="addToCart">
     <fieldset>
       <input value="{{product.id}}" class='text-field' type="hidden" name='id'><br> <br>
-      <input class='text-field' type='number' name='quantity' placeholder="qty"><br><br>
       <button class="btn btn-primary btn-lg" type="submit">Add to Cart</button>
     </fieldset><br>
     <div></div>


### PR DESCRIPTION
Removes the quantity field above the add to order button on the
products page. Quantity defaults to 1 in the cart and can be changed
from the cart page before proceeding to checkout.