### PR TITLE
Fix new user cart bug

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -43,7 +43,7 @@ const signOutSuccess = (data) => {
   $('.logged-out').show()
   store.cart = []
   store.orders = []
-  store.currentOrder = {}
+  store.currentOrder = null
   store.products = []
   store.user = {}
   $('#previousOrderTable tbody').empty()

--- a/assets/scripts/products/ui.js
+++ b/assets/scripts/products/ui.js
@@ -117,6 +117,8 @@ const showAllProductsFailure = function () {
 
 // create a cart if there isn't one and if there is one then send a patch request to update the existing cart
 const carriageBoy = () => {
+  console.log('carriageboy')
+  console.log(store.currentOrder)
   if (!store.currentOrder) {
     const data = {
       'order': {


### PR DESCRIPTION
Fixed bug that would not create a new cart for a new user when
the account is created after a previous session had been signed out.

Fixed by setting cart.currentOrder to null rather than {} so that
it would be falsy in the conditional and the new cart request would
be fired.